### PR TITLE
fix(cargo): disable debuginfo to work around a compiler bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,3 +11,9 @@ git = "https://github.com/burntsushi/quickcheck"
 
 [dev-dependencies.quickcheck_macros]
 git = "https://github.com/burntsushi/quickcheck"
+
+[profile.dev]
+debug = false
+
+[profile.test]
+debug = false


### PR DESCRIPTION
See rust-lang/rust#20127
