### PR TITLE
some small changes and upgrades

### DIFF
--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,3 +1,4 @@
+use std;
 use divide;
 
 ///Parallelizes `operation` over given `data`. 
@@ -18,19 +19,20 @@ use divide;
 /// let mut v = (1..10).collect::<Vec<usize>>();
 /// # let w = v.iter().map(|x| x + 1).collect::<Vec<usize>>();
 /// parallel::apply(v.as_mut_slice(), |x| {
-/// 	*x = *x + 1;
+///     *x = *x + 1;
 ///     //.. 
 /// });
 /// # assert_eq!(v, w);
 /// # }
 /// ```
 pub fn apply<T, F>(data: &mut [T], operation: F) where
-	T: Send,
-	F: Fn(&mut T) + Sync,
+    T: Send,
+    F: Fn(&mut T) + Sync,
 {
-	divide::divide(data, None, |data, _|{
-		for e in data.iter_mut() {
-			operation(e);
-		}
-	})
+    let granularity : usize = std::cmp::max(data.len()/std::os::num_cpus() + 1, 1);
+    divide::divide(data, granularity, |data, _|{
+        for e in data.iter_mut() {
+            operation(e);
+        }
+    })
 }

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,5 +1,4 @@
 use std;
-use divide;
 
 ///Parallelizes `operation` over given `data`. 
 ///
@@ -30,7 +29,7 @@ pub fn apply<T, F>(data: &mut [T], operation: F) where
     F: Fn(&mut T) + Sync,
 {
     let granularity : usize = std::cmp::max(data.len()/std::os::num_cpus() + 1, 1);
-    divide::divide(data, granularity, |data, _|{
+    ::divide(data, granularity, |data, _|{
         for e in data.iter_mut() {
             operation(e);
         }

--- a/src/apply.rs
+++ b/src/apply.rs
@@ -1,0 +1,36 @@
+use divide;
+
+///Parallelizes `operation` over given `data`. 
+///
+///The data are divided into chunks based on the number of processing cores 
+///available to the rust process according to `std::os::num_cpus`. 
+///
+///# Panics
+///
+///Panics if any of the underlying threads panics
+///
+///# Example
+///
+/// ```
+/// extern crate parallel;
+/// 
+/// # fn main() {
+/// let mut v = (1..10).collect::<Vec<usize>>();
+/// # let w = v.iter().map(|x| x + 1).collect::<Vec<usize>>();
+/// parallel::apply(v.as_mut_slice(), |x| {
+/// 	*x = *x + 1;
+///     //.. 
+/// });
+/// # assert_eq!(v, w);
+/// # }
+/// ```
+pub fn apply<T, F>(data: &mut [T], operation: F) where
+	T: Send,
+	F: Fn(&mut T) + Sync,
+{
+	divide::divide(data, None, |data, _|{
+		for e in data.iter_mut() {
+			operation(e);
+		}
+	})
+}

--- a/src/divide.rs
+++ b/src/divide.rs
@@ -1,4 +1,6 @@
+use std;
 use std::thread;
+use std::cmp::max;
 
 /// Parallelizes an `operation` over a mutable slice
 ///
@@ -29,7 +31,7 @@ use std::thread;
 /// let ref mut rng: XorShiftRng = rand::thread_rng().gen();
 /// let mut v = (0..1_000).map(|_| rng.gen::<f32>()).collect::<Vec<_>>();
 /// # let w = v.iter().map(|x| x.sin()).collect::<Vec<_>>();
-/// parallel::divide(v.as_mut_slice(), 100, |data, _| {
+/// parallel::divide(v.as_mut_slice(), Some(100), |data, _| {
 ///     for x in data.iter_mut() {
 ///         *x = x.sin();
 ///     }
@@ -37,16 +39,22 @@ use std::thread;
 /// # assert_eq!(v, w);
 /// # }
 /// ```
-pub fn divide<T, F>(data: &mut [T], granularity: usize, operation: F) where
+pub fn divide<T, F>(data: &mut [T], granularity: Option<usize>, operation: F) where
     T: Send,
     F: Fn(&mut [T], usize) + Sync,
 {
-    assert!(granularity > 0);
+    let true_granularity : usize = match granularity {
+        None => max(data.len()/std::os::num_cpus(), 1),
+        Some(granularity) => (|| {
+            assert!(granularity > 0);
+            granularity
+        })()
+    };
 
     let operation = &operation;
-    let guards: Vec<_> = data.chunks_mut(granularity).zip(0..).map(|(chunk, i)| {
+    let guards: Vec<_> = data.chunks_mut(true_granularity).zip(0..).map(|(chunk, i)| {
         thread::scoped(move || {
-            (*operation)(chunk, i * granularity)
+            (*operation)(chunk, i * true_granularity)
         })
     }).collect();
 
@@ -72,7 +80,7 @@ mod test {
         let mut clone = iter::repeat(0f64).take(size).collect::<Vec<_>>();
 
         let original_slice = &*original;
-        super::divide(&mut *clone, granularity, |data, offset| {
+        super::divide(&mut *clone, Some(granularity), |data, offset| {
             for (i, x) in data.iter_mut().enumerate() {
                 *x = original_slice[offset + i]
             }
@@ -89,7 +97,7 @@ mod test {
 
         let mut v = iter::repeat(None::<f64>).take(size).collect::<Vec<_>>();
 
-        super::divide(&mut *v, granularity, |data, _| {
+        super::divide(&mut *v, Some(granularity), |data, _| {
             let mut rng: XorShiftRng = rand::thread_rng().gen();
 
             for x in data.iter_mut() {

--- a/src/divide.rs
+++ b/src/divide.rs
@@ -2,8 +2,7 @@ use std::thread;
 
 /// Parallelizes an `operation` over a mutable slice
 ///
-/// The `data` will be divided in chunks of `granularity` size. If `granularity` is None,
-/// then the chunk sise will depend on the number of processors available to rust.
+/// The `data` will be divided in chunks of `granularity` size.
 ///  A new thread will be spawned to "operate" over each chunk.
 ///
 /// `operation` will receive two arguments:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 #![feature(core)]
 #![feature(plugin)]
 #![feature(std_misc)]
+#![feature(os)]
 #![cfg_attr(test, plugin(quickcheck_macros))]
 
 #[cfg(test)]
@@ -28,5 +29,7 @@ extern crate quickcheck;
 extern crate rand;
 
 pub use divide::divide;
+pub use apply::apply;
 
 mod divide;
+mod apply;


### PR DESCRIPTION
I added some slightly simpler syntax and allowed the granularity to be an optional parameter. I think the `apply` is pretty interesting because it can be used to replace loops pretty easily such as 

``` rust
for e in elems {
    func(e);
}
// can now be
parallel::apply(elems, |e| {
    func(e);
    // not load balanced but at least using up all of the processors.
})
```
